### PR TITLE
Log AlphaZero adapter to gomoku-battle/log/alphazero.log

### DIFF
--- a/gomoku-battle-alphazero/alphazero_adapter.py
+++ b/gomoku-battle-alphazero/alphazero_adapter.py
@@ -31,8 +31,9 @@ _ADAPTER_DIR = os.path.dirname(os.path.abspath(__file__))
 # Root of the alphazero-board-games submodule (sibling of this adapter dir).
 _SUBMODULE_DIR = os.path.join(os.path.dirname(_ADAPTER_DIR), "alphazero-board-games")
 
-# Log file lives next to this script; mode='w' clears previous logs each run.
-_LOG_FILE = os.path.join(_ADAPTER_DIR, "alphazero.log")
+# Log file lives in the gomoku-battle/log directory; mode='w' clears previous logs each run.
+_LOG_DIR = os.path.join(os.path.dirname(_ADAPTER_DIR), "log")
+_LOG_FILE = os.path.join(_LOG_DIR, "alphazero.log")
 
 
 def _pick_ai_action(mcts, board, player):
@@ -56,6 +57,7 @@ def _command_to_player(command: str) -> str:
 
 def main():
     # Log to a file (cleared each run) so stdout stays clean for JSON protocol.
+    os.makedirs(_LOG_DIR, exist_ok=True)
     handler = logging.FileHandler(_LOG_FILE, mode="w")
     handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
     logging.basicConfig(level=logging.INFO, handlers=[handler])


### PR DESCRIPTION
### Motivation
- Centralize adapter logs into the shared `gomoku-battle/log` directory so logs are available alongside other project logs and not stored inside the adapter package directory.

### Description
- Introduced `_LOG_DIR = os.path.join(os.path.dirname(_ADAPTER_DIR), "log")` and updated `_LOG_FILE` to point to `alphazero.log` inside that directory.
- Ensure the directory exists by calling `os.makedirs(_LOG_DIR, exist_ok=True)` before creating the `logging.FileHandler`.

### Testing
- Ran `python -m py_compile gomoku-battle-alphazero/alphazero_adapter.py` which completed successfully.

------
