### PR TITLE
Add `--simulation-num` CLI option to AlphaZero adapter (default 5000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ player.white.cmd=java -jar bin/gomoku-battle-alphabetasearch-0.0.1-SNAPSHOT-jar-
 player.white.alias=alpha-beta-search
 ```
 
+For the AlphaZero adapter, you can pass MCTS settings directly in `player.xxxxx.cmd`, for example: `--simulation-num=5000`.
+
 ## 🔌 AI Agent API
 The console creates a subprocess for each AI agent. Communication is via **stdin** (JSON request) and **stdout** (JSON response).
 

--- a/battle.properties
+++ b/battle.properties
@@ -2,5 +2,5 @@
 player.black.cmd=java -jar bin/gomoku-battle-alphabetasearch-0.0.1-SNAPSHOT-jar-with-dependencies.jar
 player.black.alias=alpha-beta-search
 
-player.white.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py
+player.white.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000
 player.white.alias=alphazero


### PR DESCRIPTION
### Motivation
- Allow configuring the AlphaZero MCTS simulation count from the battle command so matches can tune search effort without editing code. 
- Provide a sensible default of `5000` simulations to avoid relying on a hardcoded or missing value.

### Description
- Added CLI parsing using `argparse` and a `--simulation-num` option with default `5000` in `gomoku-battle-alphazero/alphazero_adapter.py` and wired the value into `config.simulation_num` before MCTS initialization. 
- Emit an informational log `MCTS simulation_num=%d` showing the chosen simulation count at startup. 
- Updated `battle.properties` to show the AlphaZero adapter started with `--simulation-num=5000` and documented the option in `README.md` so `player.xxxxx.cmd` can pass MCTS settings. 

### Testing
- Verified the adapter compiles with `python -m py_compile gomoku-battle-alphazero/alphazero_adapter.py`, which completed successfully.

------
