### PR TITLE
Improve latest-move visibility in dashboard UI

### DIFF
--- a/gomoku-battle-core/src/main/java/com/zhixiangli/gomoku/core/service/ChessboardService.java
+++ b/gomoku-battle-core/src/main/java/com/zhixiangli/gomoku/core/service/ChessboardService.java
@@ -99,6 +99,9 @@ public class ChessboardService {
 
         // make move.
         chessboardProperty[point.x][point.y].set(currentChessType.get());
+        lastMovePoint.set(new Point(point));
+        history.add(Pair.of(currentChessType.get(), new Point(point)));
+
         final Chessboard chessboard = getChessboard();
         if (GameReferee.isWin(chessboard, point)) { // if win.
             final ChessState winner = (ChessType.BLACK == currentChessType.get()) ? ChessState.BLACK_WIN : ChessState.WHITE_WIN;
@@ -108,8 +111,6 @@ public class ChessboardService {
             chessStateProperty.set(ChessState.GAME_DRAW);
             LOGGER.info("game over, draw");
         } else {
-            lastMovePoint.set(new Point(point));
-            history.add(Pair.of(currentChessType.get(), new Point(point)));
             // finish this move, and change the current chess type and current
             // player.
             currentChessType.set(GameReferee.nextChessType(currentChessType.get()));

--- a/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardCellPane.java
+++ b/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardCellPane.java
@@ -36,6 +36,12 @@ class DashboardCellPane extends Pane {
     private Circle cellCircle;
 
     /**
+     * marker for latest move.
+     */
+    @FXML
+    private Circle lastMoveMarker;
+
+    /**
      * horizontal grid line through cell center.
      */
     @FXML
@@ -107,32 +113,47 @@ class DashboardCellPane extends Pane {
         // radius of this chess piece.
         cellCircle.radiusProperty().bind(Bindings.min(cellPane.widthProperty(), cellPane.heightProperty()).divide(2.5));
 
+        // location and size for latest move marker.
+        lastMoveMarker.layoutXProperty().bind(cellPane.widthProperty().divide(2));
+        lastMoveMarker.layoutYProperty().bind(cellPane.heightProperty().divide(2));
+        lastMoveMarker.radiusProperty().bind(Bindings.min(cellPane.widthProperty(), cellPane.heightProperty()).divide(8));
+
         // the chess type of this cell, and add listener when the chess type
         // is changed.
         chessboardService.addChessboardChangeListener(position,
-                (observable, oldValue, newValue) -> updateCellPane(newValue, true));
-        updateCellPane(ChessType.EMPTY, true);
+                (observable, oldValue, newValue) -> updateCellPane(newValue));
+        updateCellPane(chessboardService.getChessboard(position));
 
         chessboardService.addLastMovePointChangeListener((observable, oldValue, newValue) -> {
-            if (position.equals(oldValue)) {
-                updateCellPane(chessboardService.getChessboard(oldValue), false);
+            if (position.equals(oldValue) || position.equals(newValue)) {
+                updateCellPane(chessboardService.getChessboard(position));
             }
         });
 
     }
 
-    private void updateCellPane(final ChessType chessType, final boolean isLatestPosition) {
+    private void updateCellPane(final ChessType chessType) {
         if (ChessType.EMPTY == chessType) {
             cellCircle.visibleProperty().set(false);
+            lastMoveMarker.visibleProperty().set(false);
+            return;
+        }
+
+        cellCircle.visibleProperty().set(true);
+        boolean isLatestPosition = position.equals(chessboardService.getLastMovePoint());
+
+        if (isLatestPosition) {
+            cellCircle.setFill((ChessType.BLACK == chessType) ? Color.rgb(20, 20, 20) : Color.rgb(245, 245, 240));
+            cellCircle.setStroke((ChessType.BLACK == chessType) ? Color.rgb(235, 205, 120) : Color.rgb(95, 75, 25));
+            cellCircle.setStrokeWidth(2.0);
+            lastMoveMarker.setFill((ChessType.BLACK == chessType) ? Color.rgb(245, 245, 240) : Color.rgb(35, 35, 35));
+            lastMoveMarker.setStroke((ChessType.BLACK == chessType) ? Color.rgb(35, 35, 35) : Color.rgb(255, 255, 255));
+            lastMoveMarker.visibleProperty().set(true);
         } else {
-            cellCircle.visibleProperty().set(true);
-            if (isLatestPosition) {
-                cellCircle.setFill((ChessType.BLACK == chessType) ? Color.rgb(20, 20, 20) : Color.rgb(240, 240, 235));
-                cellCircle.setStroke((ChessType.BLACK == chessType) ? Color.rgb(60, 60, 60) : Color.rgb(180, 180, 170));
-            } else {
-                cellCircle.setFill((ChessType.BLACK == chessType) ? Color.rgb(50, 50, 50) : Color.rgb(225, 225, 220));
-                cellCircle.setStroke(Color.TRANSPARENT);
-            }
+            cellCircle.setFill((ChessType.BLACK == chessType) ? Color.rgb(50, 50, 50) : Color.rgb(225, 225, 220));
+            cellCircle.setStroke((ChessType.BLACK == chessType) ? Color.rgb(35, 35, 35) : Color.rgb(180, 180, 170));
+            cellCircle.setStrokeWidth(0.8);
+            lastMoveMarker.visibleProperty().set(false);
         }
     }
 

--- a/gomoku-battle-dashboard/src/main/resources/cell_pane.fxml
+++ b/gomoku-battle-dashboard/src/main/resources/cell_pane.fxml
@@ -17,5 +17,6 @@
             <DropShadow radius="3" offsetX="1" offsetY="2" color="rgba(0,0,0,0.5)" />
          </effect>
       </Circle>
+      <Circle fx:id="lastMoveMarker" layoutX="20.0" layoutY="20.0" radius="4.0" fill="#ff4d4d" stroke="#fff7e0" strokeType="INSIDE" strokeWidth="1.2" visible="false" mouseTransparent="true" />
    </children>
 </fx:root>


### PR DESCRIPTION
### Motivation
- The last-placed stone is hard to distinguish on the dashboard, especially white stones that blend with the background. 
- Make the latest move visually unambiguous by adding an explicit marker and stronger stone styling so players can immediately see the most recent placement.

### Description
- Add a new `lastMoveMarker` circle to `gomoku-battle-dashboard/src/main/resources/cell_pane.fxml` to serve as a visible center marker for the latest move. 
- Update `DashboardCellPane` to include the `lastMoveMarker` field, bind its position/size to the cell, and refresh rendering when either the cell content or `lastMovePoint` changes. 
- Change the per-cell rendering in `DashboardCellPane` so the latest stone is emphasized with a stronger contrasting stroke and an inverted-color center marker for black vs white stones. 
- Modify `ChessboardService.takeMove` to set `lastMovePoint` (and add to `history`) immediately after placing a stone so a winning or drawing move is still highlighted as the latest move.

### Testing
- Ran `mvn -pl gomoku-battle-dashboard -am test -DskipTests` as an automated validation step, but the build failed due to inability to resolve Maven plugin dependencies from Central (HTTP 403), so automated tests were not executed successfully.

------
