### PR TITLE
Update README: add AlphaZero agent and remove evaluation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 | **gomoku-battle-console** | The referee — manages agent subprocesses, sends/receives JSON commands |
 | **gomoku-battle-dashboard** | Real-time JavaFX dashboard to visualize the game as it unfolds |
 | **gomoku-battle-alphabetasearch** | 🏆 **A strong built-in AI agent** powered by alpha-beta pruning (see below) |
+| **gomoku-battle-alphazero** | AlphaZero adapter — integrates an MCTS + neural-network based agent via stdio |
 
 ---
 
@@ -99,12 +100,4 @@ Return the position to make a move.
 | AI | Description | Language | Command Processor |
 |----|-------------|----------|-------------------|
 | [alpha-beta-search](https://github.com/zhixiangli/gomoku-battle/tree/master/gomoku-battle-alphabetasearch) | 🏆 Alpha-Beta Search Agent — strong built-in AI | Java | [AlphaBetaSearchAgent.java](https://github.com/zhixiangli/gomoku-battle/blob/master/gomoku-battle-alphabetasearch/src/main/java/com/zhixiangli/gomoku/alphabetasearch/AlphaBetaSearchAgent.java) |
-
-## 📈 Evaluation
-Run a batch of games and collect statistics:
-```bash
-git clone https://github.com/zhixiangli/gomoku-battle.git
-cd gomoku-battle
-sh build.sh
-sh battle.sh -c battle.properties -d
-```
+| [alphazero](https://github.com/zhixiangli/gomoku-battle/tree/master/gomoku-battle-alphazero) | AlphaZero Agent adapter with configurable MCTS simulations | Python | [alphazero_adapter.py](https://github.com/zhixiangli/gomoku-battle/blob/master/gomoku-battle-alphazero/alphazero_adapter.py) |


### PR DESCRIPTION
### Motivation
- Make the README reflect the new AlphaZero adapter so users can discover the `gomoku-battle-alphazero` integration. 
- Remove the outdated `Evaluation` section to keep documentation focused on available agents and configuration.

### Description
- Add `gomoku-battle-alphazero` to the **Project Modules** table with a short description of the adapter. 
- Add an `alphazero` row to the **AI Agent Example** table linking to the adapter directory and `alphazero_adapter.py`. 
- Remove the `## 📈 Evaluation` section and its batch-run instructions from the README.

### Testing
- Verified README content updates with `rg -n "## 📈 Evaluation|alphazero|gomoku-battle-alphazero" README.md` which returned the new alphazero entries and no evaluation section. 
- Inspected the change with `git diff -- README.md` to confirm only the README was modified. 
- Confirmed working tree status with `git status --short` to ensure no unintended files were changed.

------
