### PR TITLE
Use 'Alphabeta Search' in battle SVG title

### DIFF
--- a/assets/black-alphabetasearch-vs-white-alphazero.svg
+++ b/assets/black-alphabetasearch-vs-white-alphazero.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="900" height="1000" viewBox="0 0 900 1000">
 <rect width="100%" height="100%" fill="#f3d7a4"/>
-<text x="450" y="32" text-anchor="middle" font-size="24" fill="#2b1d0e" font-family="Arial, sans-serif">Black (alpha-beta-search) vs White (AlphaZero)</text>
+<text x="450" y="32" text-anchor="middle" font-size="24" fill="#2b1d0e" font-family="Arial, sans-serif">Black (Alphabeta Search) vs White (AlphaZero)</text>
 <line x1="60.00" y1="60.00" x2="60.00" y2="840.00" stroke="#6b4f2a" stroke-width="1.4"/>
 <line x1="60.00" y1="60.00" x2="840.00" y2="60.00" stroke="#6b4f2a" stroke-width="1.4"/>
 <line x1="115.71" y1="60.00" x2="115.71" y2="840.00" stroke="#6b4f2a" stroke-width="1.4"/>


### PR DESCRIPTION
### Motivation
- Correct the black player label in the battle SVG so it displays the intended name `Alphabeta Search` instead of the hyphenated token `alpha-beta-search`.

### Description
- Updated the title text in `assets/black-alphabetasearch-vs-white-alphazero.svg` so the header reads `Black (Alphabeta Search) vs White (AlphaZero)`.

### Testing
- Verified the change with `rg -n "Alphabeta Search|alpha-beta-search" assets/black-alphabetasearch-vs-white-alphazero.svg` which shows the updated string, and committed the file change.

------
