### PR TITLE
Improve first-game UX: start on board click and clarify ready-state announcement

### DIFF
--- a/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardCellPane.java
+++ b/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardCellPane.java
@@ -1,6 +1,7 @@
 package com.zhixiangli.gomoku.dashboard.javafx;
 
 import com.zhixiangli.gomoku.console.common.PlayerProperties;
+import com.zhixiangli.gomoku.core.chessboard.ChessState;
 import com.zhixiangli.gomoku.core.chessboard.ChessType;
 import com.zhixiangli.gomoku.core.common.GomokuConst;
 import com.zhixiangli.gomoku.core.service.ChessboardService;
@@ -163,6 +164,10 @@ class DashboardCellPane extends Pane {
      */
     @FXML
     public void takeMove() {
+        if (chessboardService.getChessState() == ChessState.GAME_READY) {
+            chessboardService.restart();
+        }
+
         final ChessType chessType = chessboardService.getCurrentChessType();
         if ((chessType != ChessType.BLACK) && (chessType != ChessType.WHITE)) {
             return;

--- a/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardController.java
+++ b/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardController.java
@@ -67,12 +67,19 @@ public class DashboardController {
         chessboardService.addChessStateChangeListener(
                 (observable, oldValue, newValue) -> {
                     if (Platform.isFxApplicationThread()) {
-                        announcementArea.setText(newValue.name());
+                        announcementArea.setText(getAnnouncementText(newValue));
                     } else {
-                        Platform.runLater(() -> announcementArea.setText(newValue.name()));
+                        Platform.runLater(() -> announcementArea.setText(getAnnouncementText(newValue)));
                     }
                 });
-        announcementArea.setText(ChessState.GAME_READY.name());
+        announcementArea.setText(getAnnouncementText(ChessState.GAME_READY));
+    }
+
+    private String getAnnouncementText(final ChessState chessState) {
+        if (ChessState.GAME_READY == chessState) {
+            return "Click board or NEW GAME to start";
+        }
+        return chessState.name();
     }
 
     private void initializeGridPane() throws IOException {


### PR DESCRIPTION
### Motivation
- First-time users clicking the board while the UI is in the ready state received no feedback, which is a confusing UX; the change makes the first click behave as users expect.  
- The announcement label did not guide users to how to start a game, so it was updated to explicitly instruct users to click the board or press the NEW GAME button.

### Description
- When a board cell is clicked and the `ChessState` is `GAME_READY`, the code now calls `chessboardService.restart()` so the first click starts a new game (`gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardCellPane.java`).
- The announcement text is now produced by `getAnnouncementText(...)` and shows `"Click board or NEW GAME to start"` when state is `GAME_READY`, while all other states continue to display their existing `name()` labels (`gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardController.java`).
- Existing move-validation and player-command checks (AI/human) are preserved and unchanged after the automatic restart.

### Testing
- Attempted to run the module tests with `mvn -pl gomoku-battle-dashboard -am test -DskipTests`, which failed due to dependency/plugin resolution from Maven Central returning HTTP 403 and prevented running the automated build/tests in this environment.  
- No automated tests were executed successfully because of the environment dependency resolution error.

------
