### PR TITLE
docs: recommend AlphaZero black vs human white in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ sh battle.sh -c battle.properties
 ## ⚙️ Configuration
 Configure agents in **battle.properties**:
 
+> Recommended quick-start setup: play as **White (Human)** against **Black (AlphaZero)** to experience a strong AI opening first.
+
 + **player.xxxxx.alias**: display name for the agent.
 + **player.xxxxx.cmd**: shell command to start the agent process. Leave blank (or omit) for human play — the player alias defaults to `Human`.
 
@@ -49,11 +51,11 @@ player.white.alias=AlphaZero
 #### Human vs AI
 Leave `player.xxxxx.cmd` blank to play as a human. The alias defaults to `Human` when no command is set.
 ```properties
-player.black.cmd=
-player.black.alias=
+player.black.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000
+player.black.alias=AlphaZero
 
-player.white.cmd=java -jar bin/gomoku-battle-alphabetasearch-0.0.1-SNAPSHOT-jar-with-dependencies.jar
-player.white.alias=Alpha-Beta Search
+player.white.cmd=
+player.white.alias=
 ```
 
 For AlphaZero, pass MCTS options in `player.xxxxx.cmd`, e.g. `--simulation-num=5000`.


### PR DESCRIPTION
### Motivation
- Provide a quick-start recommendation so users can immediately try a strong AI opponent by playing as White (Human) against Black (AlphaZero).

### Description
- Added a recommended quick-start note in the `Configuration` section advising to play as **White (Human)** vs **Black (AlphaZero)**.
- Updated the `Human vs AI` example so `player.black.cmd` runs AlphaZero (`uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000`) and `player.white.cmd` is left blank to represent a human player.

### Testing
- Verified the `README.md` diff contains the new recommendation and the adjusted example and confirmed formatting; no automated test suite changes were required.

------
