### PR TITLE
Add dashboard player selectors and centralize agent commands in battle.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,32 +33,23 @@ sh battle.sh -c battle.properties
 ```
 
 ## ⚙️ Configuration
-Configure agents in **battle.properties**:
+Configure agent commands in **battle.properties**. Player side (Black/White) is now selected in the dashboard UI with a dropdown: **Human**, **Alpha-Beta Search**, or **AlphaZero**.
 
-> Recommended quick-start setup: play as **White (Human)** against **Black (AlphaZero)** to experience a strong AI opening first.
-
-+ **player.xxxxx.alias**: display name for the agent.
-+ **player.xxxxx.cmd**: shell command to start the agent process. Leave blank (or omit) for human play — the player alias defaults to `Human`.
++ **agent.alphabeta.cmd**: shell command to start the Alpha-Beta Search agent.
++ **agent.alphazero.cmd**: shell command to start the AlphaZero agent.
 
 ### Configuration Example
 ```properties
-player.black.cmd=java -jar bin/gomoku-battle-alphabetasearch-0.0.1-SNAPSHOT-jar-with-dependencies.jar
-player.black.alias=Alpha-Beta Search
-player.white.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000
-player.white.alias=AlphaZero
+agent.alphabeta.cmd=java -jar bin/gomoku-battle-alphabetasearch-0.0.1-SNAPSHOT-jar-with-dependencies.jar
+agent.alphazero.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000
 ```
 
-#### Human vs AI
-Leave `player.xxxxx.cmd` blank to play as a human. The alias defaults to `Human` when no command is set.
-```properties
-player.black.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000
-player.black.alias=AlphaZero
+In the dashboard, you can choose each side independently (Black and White):
+- Human
+- Alpha-Beta Search
+- AlphaZero
 
-player.white.cmd=
-player.white.alias=
-```
-
-For AlphaZero, pass MCTS options in `player.xxxxx.cmd`, e.g. `--simulation-num=5000`.
+For AlphaZero, pass MCTS options in `agent.alphazero.cmd`, e.g. `--simulation-num=5000`.
 
 ## 🔌 AI Agent API
 The console spawns each agent as a subprocess and communicates over JSON (`stdin` / `stdout`).

--- a/battle.properties
+++ b/battle.properties
@@ -1,6 +1,3 @@
-# alpha-beta pruning (black) vs alphazero (white)
-player.black.cmd=java -jar bin/gomoku-battle-alphabetasearch-0.0.1-SNAPSHOT-jar-with-dependencies.jar
-player.black.alias=alpha-beta-search
-
-player.white.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000
-player.white.alias=alphazero
+# commands for built-in agents
+agent.alphabeta.cmd=java -jar bin/gomoku-battle-alphabetasearch-0.0.1-SNAPSHOT-jar-with-dependencies.jar
+agent.alphazero.cmd=uv run --project alphazero-board-games python gomoku-battle-alphazero/alphazero_adapter.py --simulation-num=5000

--- a/gomoku-battle-console/src/main/java/com/zhixiangli/gomoku/console/ConsoleMaster.java
+++ b/gomoku-battle-console/src/main/java/com/zhixiangli/gomoku/console/ConsoleMaster.java
@@ -16,6 +16,8 @@ import org.slf4j.LoggerFactory;
 
 import java.awt.Point;
 import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author zhixiangli
@@ -26,20 +28,10 @@ public class ConsoleMaster {
 
     private final ChessboardService chessboardService = ChessboardService.getInstance();
 
-    private ConsoleProcess blackPlayerProcess;
-
-    private ConsoleProcess whitePlayerProcess;
+    private final Map<String, ConsoleProcess> commandProcessMap = new ConcurrentHashMap<>();
 
     public ConsoleMaster(final String playProperties) throws IOException {
         PlayerProperties.parse(playProperties);
-        if (StringUtils.isNotBlank(PlayerProperties.playerBlackCommand)) {
-            LOGGER.info("fork black player process: {}", PlayerProperties.playerBlackCommand);
-            blackPlayerProcess = new ConsoleProcess(PlayerProperties.playerBlackCommand);
-        }
-        if (StringUtils.isNotBlank(PlayerProperties.playerWhiteCommand)) {
-            LOGGER.info("fork white player process: {}", PlayerProperties.playerWhiteCommand);
-            whitePlayerProcess = new ConsoleProcess(PlayerProperties.playerWhiteCommand);
-        }
         // when chess type changed, notify the process to make a next move.
         chessboardService.addCurrentChessTypeChangeListener(
                 (observable, oldValue, newValue) -> new Thread(() -> callForAction(newValue)).start());
@@ -49,16 +41,38 @@ public class ConsoleMaster {
         try {
             switch (chessType) {
                 case BLACK:
-                    sendActionCommand(blackPlayerProcess, ConsoleCommand.NEXT_BLACK);
+                    sendActionCommand(getProcess(chessType), ConsoleCommand.NEXT_BLACK);
                     break;
                 case WHITE:
-                    sendActionCommand(whitePlayerProcess, ConsoleCommand.NEXT_WHITE);
+                    sendActionCommand(getProcess(chessType), ConsoleCommand.NEXT_WHITE);
                     break;
                 case EMPTY:
                 default:
             }
         } catch (final IOException e) {
             LOGGER.error("call for action error.", e);
+        }
+    }
+
+    private ConsoleProcess getProcess(final ChessType chessType) throws IOException {
+        final String command = PlayerProperties.getPlayerCommand(chessType);
+        if (StringUtils.isBlank(command)) {
+            return null;
+        }
+        try {
+            return commandProcessMap.computeIfAbsent(command, key -> {
+                try {
+                    LOGGER.info("fork player process: {}", key);
+                    return new ConsoleProcess(key);
+                } catch (final IOException e) {
+                    throw new IllegalStateException("fork player process error", e);
+                }
+            });
+        } catch (final IllegalStateException e) {
+            if (e.getCause() instanceof IOException) {
+                throw (IOException) e.getCause();
+            }
+            throw e;
         }
     }
 

--- a/gomoku-battle-console/src/main/java/com/zhixiangli/gomoku/console/common/PlayerProperties.java
+++ b/gomoku-battle-console/src/main/java/com/zhixiangli/gomoku/console/common/PlayerProperties.java
@@ -1,5 +1,6 @@
 package com.zhixiangli.gomoku.console.common;
 
+import com.zhixiangli.gomoku.core.chessboard.ChessType;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.builder.fluent.Configurations;
 import org.apache.commons.configuration2.ex.ConfigurationException;
@@ -18,34 +19,88 @@ public class PlayerProperties {
 
     public static final String PLAYER_CONF = "player";
 
-    public static String playerBlackCommand;
-
-    public static String playerBlackAlias;
-
-    public static String playerWhiteCommand;
-
-    public static String playerWhiteAlias;
-
     private static final String HUMAN_ALIAS = "Human";
+    private static final String ALPHAZERO_ALIAS = "AlphaZero";
+    private static final String ALPHABETA_ALIAS = "Alpha-Beta Search";
+
+    private static String alphazeroCommand;
+    private static String alphabetaCommand;
+
+    private static PlayerType blackPlayerType = PlayerType.ALPHABETA;
+    private static PlayerType whitePlayerType = PlayerType.ALPHAZERO;
 
     private PlayerProperties() {
     }
 
-    public static void parse(final String configPath) {
+    public static synchronized void parse(final String configPath) {
+        blackPlayerType = PlayerType.ALPHABETA;
+        whitePlayerType = PlayerType.ALPHAZERO;
         try {
             final PropertiesConfiguration playerConfig = new Configurations().properties(new File(configPath));
-            playerBlackCommand = playerConfig.getString("player.black.cmd");
-            playerBlackAlias = playerConfig.getString("player.black.alias");
-            playerWhiteCommand = playerConfig.getString("player.white.cmd");
-            playerWhiteAlias = playerConfig.getString("player.white.alias");
-            if (StringUtils.isBlank(playerBlackCommand) && StringUtils.isBlank(playerBlackAlias)) {
-                playerBlackAlias = HUMAN_ALIAS;
-            }
-            if (StringUtils.isBlank(playerWhiteCommand) && StringUtils.isBlank(playerWhiteAlias)) {
-                playerWhiteAlias = HUMAN_ALIAS;
-            }
+            alphazeroCommand = playerConfig.getString("agent.alphazero.cmd");
+            alphabetaCommand = playerConfig.getString("agent.alphabeta.cmd");
         } catch (final ConfigurationException e) {
             LOGGER.error("load player config error", e);
+        }
+    }
+
+    public static synchronized void setPlayerType(final ChessType chessType, final PlayerType playerType) {
+        final PlayerType newType = playerType == null ? PlayerType.HUMAN : playerType;
+        if (chessType == ChessType.BLACK) {
+            blackPlayerType = newType;
+        } else if (chessType == ChessType.WHITE) {
+            whitePlayerType = newType;
+        }
+    }
+
+    public static synchronized PlayerType getPlayerType(final ChessType chessType) {
+        if (chessType == ChessType.BLACK) {
+            return blackPlayerType;
+        }
+        if (chessType == ChessType.WHITE) {
+            return whitePlayerType;
+        }
+        return PlayerType.HUMAN;
+    }
+
+    public static synchronized String getPlayerAlias(final ChessType chessType) {
+        return getPlayerType(chessType).getAlias();
+    }
+
+    public static synchronized String getPlayerCommand(final ChessType chessType) {
+        return getPlayerType(chessType).getCommand(alphazeroCommand, alphabetaCommand);
+    }
+
+    public enum PlayerType {
+        HUMAN(HUMAN_ALIAS),
+        ALPHAZERO(ALPHAZERO_ALIAS),
+        ALPHABETA(ALPHABETA_ALIAS);
+
+        private final String alias;
+
+        PlayerType(final String alias) {
+            this.alias = alias;
+        }
+
+        public String getAlias() {
+            return alias;
+        }
+
+        public String getCommand(final String alphazeroCmd, final String alphabetaCmd) {
+            switch (this) {
+                case ALPHAZERO:
+                    return StringUtils.trimToEmpty(alphazeroCmd);
+                case ALPHABETA:
+                    return StringUtils.trimToEmpty(alphabetaCmd);
+                case HUMAN:
+                default:
+                    return StringUtils.EMPTY;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return alias;
         }
     }
 

--- a/gomoku-battle-console/src/test/java/com/zhixiangli/gomoku/console/common/PlayerPropertiesTest.java
+++ b/gomoku-battle-console/src/test/java/com/zhixiangli/gomoku/console/common/PlayerPropertiesTest.java
@@ -1,5 +1,7 @@
 package com.zhixiangli.gomoku.console.common;
 
+import com.zhixiangli.gomoku.console.common.PlayerProperties.PlayerType;
+import com.zhixiangli.gomoku.core.chessboard.ChessType;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -7,23 +9,30 @@ import static org.junit.Assert.assertEquals;
 public class PlayerPropertiesTest {
 
     @Test
-    public void testHumanPlayerDefaultAlias() {
+    public void testDefaultPlayerTypesAndAlias() {
         PlayerProperties.parse(getClass().getClassLoader().getResource("human_player.properties").getPath());
-        assertEquals("Human", PlayerProperties.playerBlackAlias);
-        assertEquals("Human", PlayerProperties.playerWhiteAlias);
+        assertEquals(PlayerType.ALPHABETA, PlayerProperties.getPlayerType(ChessType.BLACK));
+        assertEquals(PlayerType.ALPHAZERO, PlayerProperties.getPlayerType(ChessType.WHITE));
+        assertEquals("Alpha-Beta Search", PlayerProperties.getPlayerAlias(ChessType.BLACK));
+        assertEquals("AlphaZero", PlayerProperties.getPlayerAlias(ChessType.WHITE));
     }
 
     @Test
-    public void testAiPlayerAliasUnchanged() {
+    public void testPlayerTypeCanBeUpdated() {
         PlayerProperties.parse(getClass().getClassLoader().getResource("ai_player.properties").getPath());
-        assertEquals("TestBlack", PlayerProperties.playerBlackAlias);
-        assertEquals("TestWhite", PlayerProperties.playerWhiteAlias);
+        PlayerProperties.setPlayerType(ChessType.BLACK, PlayerType.HUMAN);
+        PlayerProperties.setPlayerType(ChessType.WHITE, PlayerType.ALPHABETA);
+
+        assertEquals("", PlayerProperties.getPlayerCommand(ChessType.BLACK));
+        assertEquals("echo alpha-beta", PlayerProperties.getPlayerCommand(ChessType.WHITE));
+        assertEquals("Human", PlayerProperties.getPlayerAlias(ChessType.BLACK));
+        assertEquals("Alpha-Beta Search", PlayerProperties.getPlayerAlias(ChessType.WHITE));
     }
 
     @Test
-    public void testMixedPlayerAlias() {
+    public void testAlphaZeroCommand() {
         PlayerProperties.parse(getClass().getClassLoader().getResource("mixed_player.properties").getPath());
-        assertEquals("Human", PlayerProperties.playerBlackAlias);
-        assertEquals("TestWhite", PlayerProperties.playerWhiteAlias);
+        PlayerProperties.setPlayerType(ChessType.BLACK, PlayerType.ALPHAZERO);
+        assertEquals("echo alpha-zero", PlayerProperties.getPlayerCommand(ChessType.BLACK));
     }
 }

--- a/gomoku-battle-console/src/test/resources/ai_player.properties
+++ b/gomoku-battle-console/src/test/resources/ai_player.properties
@@ -1,5 +1,2 @@
-player.black.cmd=echo black
-player.black.alias=TestBlack
-
-player.white.cmd=echo white
-player.white.alias=TestWhite
+agent.alphabeta.cmd=echo alpha-beta
+agent.alphazero.cmd=echo alpha-zero

--- a/gomoku-battle-console/src/test/resources/human_player.properties
+++ b/gomoku-battle-console/src/test/resources/human_player.properties
@@ -1,5 +1,2 @@
-player.black.cmd=
-player.black.alias=
-
-player.white.cmd=
-player.white.alias=
+agent.alphabeta.cmd=echo alphabeta
+agent.alphazero.cmd=echo alphazero

--- a/gomoku-battle-console/src/test/resources/mixed_player.properties
+++ b/gomoku-battle-console/src/test/resources/mixed_player.properties
@@ -1,5 +1,2 @@
-player.black.cmd=
-player.black.alias=
-
-player.white.cmd=echo white
-player.white.alias=TestWhite
+agent.alphabeta.cmd=echo alpha-beta
+agent.alphazero.cmd=echo alpha-zero

--- a/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardCellPane.java
+++ b/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardCellPane.java
@@ -172,10 +172,7 @@ class DashboardCellPane extends Pane {
         if ((chessType != ChessType.BLACK) && (chessType != ChessType.WHITE)) {
             return;
         }
-        if (chessType == ChessType.BLACK && StringUtils.isNotBlank(PlayerProperties.playerBlackCommand)) {
-            return;
-        }
-        if (chessType == ChessType.WHITE && StringUtils.isNotBlank(PlayerProperties.playerWhiteCommand)) {
+        if (StringUtils.isNotBlank(PlayerProperties.getPlayerCommand(chessType))) {
             return;
         }
 

--- a/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardController.java
+++ b/gomoku-battle-dashboard/src/main/java/com/zhixiangli/gomoku/dashboard/javafx/DashboardController.java
@@ -1,11 +1,15 @@
 package com.zhixiangli.gomoku.dashboard.javafx;
 
 import com.zhixiangli.gomoku.console.common.PlayerProperties;
+import com.zhixiangli.gomoku.console.common.PlayerProperties.PlayerType;
 import com.zhixiangli.gomoku.core.chessboard.ChessState;
+import com.zhixiangli.gomoku.core.chessboard.ChessType;
 import com.zhixiangli.gomoku.core.common.GomokuConst;
 import com.zhixiangli.gomoku.core.service.ChessboardService;
 import javafx.application.Platform;
+import javafx.collections.FXCollections;
 import javafx.fxml.FXML;
+import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 
@@ -25,6 +29,12 @@ public class DashboardController {
     @FXML
     private Label whiteAliasArea;
 
+    @FXML
+    private ChoiceBox<PlayerType> blackPlayerChoice;
+
+    @FXML
+    private ChoiceBox<PlayerType> whitePlayerChoice;
+
     /**
      * announcement label.
      */
@@ -39,12 +49,14 @@ public class DashboardController {
 
     private final ChessboardService chessboardService = ChessboardService.getInstance();
 
+    private boolean initializingPlayerChoice;
+
     /**
      * initialize.
      */
     @FXML
     public void initialize() throws IOException {
-        // initialize choice box.
+        initializePlayerSelector();
         initializePlayerAlias();
 
         // add listener to update announcement when chessboard state is changed.
@@ -58,9 +70,36 @@ public class DashboardController {
         chessboardService.restart();
     }
 
+    @FXML
+    public void updateBlackPlayer() {
+        PlayerProperties.setPlayerType(ChessType.BLACK, blackPlayerChoice.getValue());
+        blackAliasArea.setText(PlayerProperties.getPlayerAlias(ChessType.BLACK));
+        if (!initializingPlayerChoice) {
+            chessboardService.restart();
+        }
+    }
+
+    @FXML
+    public void updateWhitePlayer() {
+        PlayerProperties.setPlayerType(ChessType.WHITE, whitePlayerChoice.getValue());
+        whiteAliasArea.setText(PlayerProperties.getPlayerAlias(ChessType.WHITE));
+        if (!initializingPlayerChoice) {
+            chessboardService.restart();
+        }
+    }
+
+    private void initializePlayerSelector() {
+        initializingPlayerChoice = true;
+        blackPlayerChoice.setItems(FXCollections.observableArrayList(PlayerType.values()));
+        whitePlayerChoice.setItems(FXCollections.observableArrayList(PlayerType.values()));
+        blackPlayerChoice.setValue(PlayerProperties.getPlayerType(ChessType.BLACK));
+        whitePlayerChoice.setValue(PlayerProperties.getPlayerType(ChessType.WHITE));
+        initializingPlayerChoice = false;
+    }
+
     private void initializePlayerAlias() {
-        blackAliasArea.setText(PlayerProperties.playerBlackAlias);
-        whiteAliasArea.setText(PlayerProperties.playerWhiteAlias);
+        blackAliasArea.setText(PlayerProperties.getPlayerAlias(ChessType.BLACK));
+        whiteAliasArea.setText(PlayerProperties.getPlayerAlias(ChessType.WHITE));
     }
 
     private void initializeAnnouncement() {

--- a/gomoku-battle-dashboard/src/main/resources/gomoku_pane.fxml
+++ b/gomoku-battle-dashboard/src/main/resources/gomoku_pane.fxml
@@ -34,6 +34,7 @@
                   <Label fx:id="blackAliasArea" styleClass="player-label" HBox.hgrow="ALWAYS" maxWidth="Infinity" />
                </children>
             </HBox>
+            <ChoiceBox fx:id="blackPlayerChoice" styleClass="player-choice-box" maxWidth="Infinity" onAction="#updateBlackPlayer" />
 
             <Label text="WHITE" styleClass="section-title" />
             <HBox spacing="8" alignment="CENTER_LEFT">
@@ -42,6 +43,7 @@
                   <Label fx:id="whiteAliasArea" styleClass="player-label" HBox.hgrow="ALWAYS" maxWidth="Infinity" />
                </children>
             </HBox>
+            <ChoiceBox fx:id="whitePlayerChoice" styleClass="player-choice-box" maxWidth="Infinity" onAction="#updateWhitePlayer" />
 
             <Region VBox.vgrow="ALWAYS" />
 

--- a/gomoku-battle-dashboard/src/main/resources/gomoku_style.css
+++ b/gomoku-battle-dashboard/src/main/resources/gomoku_style.css
@@ -56,6 +56,20 @@
     -fx-stroke-width: 1.5;
 }
 
+.player-choice-box {
+    -fx-background-color: #333333;
+    -fx-mark-color: #d0d0d0;
+}
+
+.player-choice-box .label {
+    -fx-text-fill: #d0d0d0;
+    -fx-font-size: 12px;
+}
+
+.player-choice-box .context-menu {
+    -fx-background-color: #2f2f2f;
+}
+
 /* ── New Game Button ───────────────────────────────────── */
 
 .new-game-button {


### PR DESCRIPTION
### Motivation
- Make it possible to choose the player type (Human / Alpha-Beta Search / AlphaZero) per side from the dashboard UI instead of relying on per-color command properties. 
- Simplify configuration by keeping agent launch commands in one place (`battle.properties`) and start agent processes lazily based on the dashboard selection. 
- Clean up legacy per-color `player.black.*` / `player.white.*` config and related code paths.

### Description
- Add per-side player selectors to the JavaFX dashboard: two `ChoiceBox<PlayerType>` controls for Black and White in `gomoku_pane.fxml` and selection handling in `DashboardController.java`, wired to `PlayerProperties.setPlayerType(...)` and `restart()` logic. 
- Replace the old per-color command/alias model with a centralized `PlayerProperties` that loads `agent.alphabeta.cmd` and `agent.alphazero.cmd` from `battle.properties`, exposes `PlayerType` (HUMAN / ALPHAZERO / ALPHABETA`), and provides `getPlayerAlias(...)` and `getPlayerCommand(...)`. 
- Change runtime agent handling in `ConsoleMaster` to lazily spawn `ConsoleProcess` instances per agent command and cache processes by command string instead of maintaining fixed `blackPlayerProcess` / `whitePlayerProcess`. 
- Update board click behavior in `DashboardCellPane` to permit manual moves only when the selected side is `Human` (i.e. when `PlayerProperties.getPlayerCommand(...)` is blank). 
- Update `battle.properties`, `README.md`, tests and test fixtures to the new property names (`agent.alphabeta.cmd`, `agent.alphazero.cmd`) and UI workflow; add CSS styling for the choice boxes. 

### Testing
- Ran `git diff --check` to validate whitespace/diff issues (passed). 
- Attempted to run module tests with `mvn -q test -pl gomoku-battle-console,gomoku-battle-dashboard -am`, but the run failed in this environment due to Maven plugin resolution from Central returning `403 Forbidden`, so unit tests could not complete here. 
- Updated and added unit tests for `PlayerProperties` under `gomoku-battle-console` (test resources and `PlayerPropertiesTest`), which should pass when Maven can resolve dependencies in the target environment.

------
