### PR TITLE
Add unit tests for AlphaBetaSearchAgent covering open-four and open-three scenarios

### DIFF
--- a/gomoku-battle-alphabetasearch/src/test/java/com/zhixiangli/gomoku/alphabetasearch/AlphaBetaSearchAgentTest.java
+++ b/gomoku-battle-alphabetasearch/src/test/java/com/zhixiangli/gomoku/alphabetasearch/AlphaBetaSearchAgentTest.java
@@ -45,4 +45,56 @@ public class AlphaBetaSearchAgentTest {
         Assert.assertTrue(new Point(5, 2).equals(point) || new Point(1, 6).equals(point));
     }
 
+    @Test
+    public void nextShouldCompleteOpenFour() {
+        /**
+         * White to move, complete an open four on row 7.
+         *
+         * ......?WWWW?...
+         *
+         * Expected: (7,6) or (7,11)
+         */
+        final Point point = agent.next("W[77];B[12];W[78];B[23];W[79];B[34];W[7a]", ChessType.WHITE);
+        Assert.assertTrue(new Point(7, 6).equals(point) || new Point(7, 11).equals(point));
+    }
+
+    @Test
+    public void nextShouldBlockOpponentOpenFour() {
+        /**
+         * White to move, must block black open four on row 7.
+         *
+         * ......?BBBB?...
+         *
+         * Expected: (7,6) or (7,11)
+         */
+        final Point point = agent.next("B[77];W[22];B[78];W[33];B[79];W[44];B[7a]", ChessType.WHITE);
+        Assert.assertTrue(new Point(7, 6).equals(point) || new Point(7, 11).equals(point));
+    }
+
+    @Test
+    public void nextShouldPreferOpenThreeExtension() {
+        /**
+         * White to move, extend open three to create stronger threat.
+         *
+         * ......?WWW?....
+         *
+         * Expected: (7,6) or (7,10)
+         */
+        final Point point = agent.next("W[77];B[22];W[78];B[33];W[79]", ChessType.WHITE);
+        Assert.assertTrue(new Point(7, 6).equals(point) || new Point(7, 10).equals(point));
+    }
+
+    @Test
+    public void nextShouldFillSpacedOpenThreeGap() {
+        /**
+         * White to move, fill the center gap in spaced open three.
+         *
+         * .......WW?W....
+         *
+         * Expected: (7,9)
+         */
+        final Point point = agent.next("W[77];B[22];W[78];B[33];W[7a]", ChessType.WHITE);
+        Assert.assertEquals(new Point(7, 9), point);
+    }
+
 }


### PR DESCRIPTION
### Motivation
- Improve test coverage for `AlphaBetaSearchAgent` decision logic in key tactical patterns such as completing an open four, blocking an opponent's open four, extending an open three, and filling a spaced open-three gap.
- Make the agent's expected move behavior explicit for several representative board sequences so regressions are easier to detect.

### Description
- Added four new tests to `AlphaBetaSearchAgentTest`: `nextShouldCompleteOpenFour`, `nextShouldBlockOpponentOpenFour`, `nextShouldPreferOpenThreeExtension`, and `nextShouldFillSpacedOpenThreeGap`.
- Each test calls `agent.next` with a compact move string (for example, `"W[77];B[12];W[78];B[23];W[79];B[34];W[7a]"`) and asserts expected board coordinates using `Assert.assertTrue` or `Assert.assertEquals` with `java.awt.Point` results.
- Retained the original `next` test and the `setUp` method that instantiates `AlphaBetaSearchAgent` to ensure consistent test initialization.
- Tests encode expected coordinates such as `(7,6)`, `(7,11)`, `(7,10)`, and `(7,9)` to validate the agent's tactical choices.

### Testing
- Ran unit tests for the modified test class `AlphaBetaSearchAgentTest` via the project's test suite (`mvn test` or equivalent), and the new tests executed successfully.
- All assertions in `AlphaBetaSearchAgentTest` passed during the automated test run.

------
