### PR TITLE
Tune Prophet evaluation weights for Gomoku threat prioritization

### DIFF
--- a/gomoku-battle-alphabetasearch/src/main/java/com/zhixiangli/gomoku/alphabetasearch/common/ProphetConst.java
+++ b/gomoku-battle-alphabetasearch/src/main/java/com/zhixiangli/gomoku/alphabetasearch/common/ProphetConst.java
@@ -18,20 +18,22 @@ public class ProphetConst {
                 {
                     put(PatternType.FIVE, 1e8);
 
-                    put(PatternType.OPEN_FOUR, 1e5);
+                    // Winning threat hierarchy (OPEN_FOUR >> HALF_OPEN_FOUR >> OPEN_THREE ...)
+                    // is tuned so that search strongly prefers immediate forcing moves.
+                    put(PatternType.OPEN_FOUR, 1e6);
 
-                    put(PatternType.HALF_OPEN_FOUR, 1e4);
+                    put(PatternType.HALF_OPEN_FOUR, 8e4);
 
-                    put(PatternType.OPEN_THREE, 3e3);
-                    put(PatternType.SPACED_OPEN_THREE, 1e3);
+                    put(PatternType.OPEN_THREE, 1e4);
+                    put(PatternType.SPACED_OPEN_THREE, 6e3);
 
-                    put(PatternType.HALF_OPEN_THREE, 1e2);
+                    put(PatternType.HALF_OPEN_THREE, 8e2);
 
-                    put(PatternType.OPEN_TWO, 5e1);
-                    put(PatternType.ONE_SPACED_OPEN_TWO, 3e1);
-                    put(PatternType.TWO_SPACED_OPEN_TWO, 1e1);
+                    put(PatternType.OPEN_TWO, 2e2);
+                    put(PatternType.ONE_SPACED_OPEN_TWO, 1.2e2);
+                    put(PatternType.TWO_SPACED_OPEN_TWO, 5e1);
 
-                    put(PatternType.HALF_OPEN_TWO, 1e0);
+                    put(PatternType.HALF_OPEN_TWO, 1e1);
 
                     put(PatternType.OTHERS, 0.0);
                 }


### PR DESCRIPTION
### Motivation
- Align the alpha-beta prophet evaluation weights with Gomoku pattern urgency so the search prioritizes immediate forcing threats over shape-building patterns.
- Increase separation between high-impact tactical patterns (e.g., `OPEN_FOUR`, `HALF_OPEN_FOUR`, `OPEN_THREE`) and lower-impact patterns to improve move ordering and heuristic guidance.

### Description
- Adjusted numeric weights in `ProphetConst.EVALUATION` (file: `gomoku-battle-alphabetasearch/src/main/java/com/zhixiangli/gomoku/alphabetasearch/common/ProphetConst.java`) to widen gaps between tactical and developmental patterns.
- Specific adjustments include: `OPEN_FOUR` 1e5 -> 1e6, `HALF_OPEN_FOUR` 1e4 -> 8e4, `OPEN_THREE` 3e3 -> 1e4, `SPACED_OPEN_THREE` 1e3 -> 6e3, `HALF_OPEN_THREE` 1e2 -> 8e2, `OPEN_TWO` 5e1 -> 2e2, `ONE_SPACED_OPEN_TWO` 3e1 -> 1.2e2, `TWO_SPACED_OPEN_TWO` 1e1 -> 5e1, and `HALF_OPEN_TWO` 1e0 -> 1e1.
- Added an inline comment documenting the intended winning-threat hierarchy so future tuning preserves strategic intent.

### Testing
- Attempted to run module unit tests with `mvn -pl gomoku-battle-alphabetasearch test -DskipTests=false` but the run failed due to Maven plugin resolution returning a remote `403 Forbidden` error, preventing completion of automated tests.
- No other automated test runs completed in this environment because remote dependency/plugin resolution was blocked.

------
