### PR TITLE
Add Dependabot config for weekly Maven updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
### Motivation

- Enable automated dependency updates for `maven` projects and standardize update commits with the prefix `chore`.

### Description

- Add `.github/dependabot.yml` containing `version: 2` and an `updates` entry that runs Dependabot for `maven` in directory `/` on a `weekly` schedule with a commit-message prefix of `chore`.

### Testing

- No automated tests were run for this configuration-only change.

------
