### PR TITLE
ci: add GitHub Actions workflow for Maven test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Run Maven tests
+        run: mvn --batch-mode test

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ sh build.sh
 sh battle.sh -c battle.properties
 ```
 
+## ✅ Run Tests
+The project is a Maven multi-module build. Unit tests live in each module's `src/test/java` directory and are executed by the Maven Surefire plugin during `test`.
+
+```bash
+mvn test
+```
+
+GitHub Actions CI runs the same command on every pull request and on pushes to `main` / `master`.
+
 ## ⚙️ Configuration
 Configure agent commands in **battle.properties**. Player side (Black/White) is now selected in the dashboard UI with a dropdown: **Human**, **Alpha-Beta Search**, or **AlphaZero**.
 


### PR DESCRIPTION
### Motivation

- Ensure the repository runs the full Maven test suite automatically on CI for every pull request and on pushes to `main`/`master` so regressions are caught early.

### Description

- Add a GitHub Actions workflow at `.github/workflows/ci.yml` that checks out the repository, sets up Temurin Java 17 with Maven caching, and runs `mvn --batch-mode test` on `pull_request` and on pushes to `main`/`master`.
- Document local testing in `README.md` by adding a short `Run Tests` section that instructs contributors to run `mvn test` and notes that CI runs the same command.

### Testing

- Ran `mvn -B test` against the multi-module project, which completed with `BUILD SUCCESS` and all module unit tests passed. 
- The Maven test run exercised tests in `gomoku-battle-core`, `gomoku-battle-console`, and `gomoku-battle-alphabetasearch` and reported no failures.

------
