### PR TITLE
ci: run AlphaZero adapter Python tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Set up Java 25
         uses: actions/setup-java@v5
@@ -22,5 +24,19 @@ jobs:
           java-version: '25'
           cache: maven
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ./alphazero-board-games
+          pip install dotdict
+
       - name: Run Maven tests
         run: mvn --batch-mode test
+
+      - name: Run AlphaZero adapter Python tests
+        run: python -m unittest discover -s gomoku-battle-alphazero/tests -p "test_*.py"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,18 +33,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ./alphazero-board-games
+          pip install pytest
 
       - name: Run Maven tests
         run: mvn --batch-mode test
 
       - name: Run Python tests
-        run: |
-          mapfile -t test_dirs < <(find . -type d -name tests -not -path './.git/*' -not -path './alphazero-board-games/*' | sort)
-          if [ ${#test_dirs[@]} -eq 0 ]; then
-            echo "No Python test directories found."
-            exit 0
-          fi
-          for test_dir in "${test_dirs[@]}"; do
-            echo "Running Python tests in ${test_dir}"
-            python -m unittest discover -s "${test_dir}" -p "test_*.py"
-          done
+        run: python -m pytest --ignore=alphazero-board-games

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ./alphazero-board-games
-          pip install dotdict
 
       - name: Run Maven tests
         run: mvn --batch-mode test
 
-      - name: Run AlphaZero adapter Python tests
-        run: python -m unittest discover -s gomoku-battle-alphazero/tests -p "test_*.py"
+      - name: Run Python tests
+        run: |
+          mapfile -t test_dirs < <(find . -type d -name tests -not -path './.git/*' -not -path './alphazero-board-games/*' | sort)
+          if [ ${#test_dirs[@]} -eq 0 ]; then
+            echo "No Python test directories found."
+            exit 0
+          fi
+          for test_dir in "${test_dirs[@]}"; do
+            echo "Running Python tests in ${test_dir}"
+            python -m unittest discover -s "${test_dir}" -p "test_*.py"
+          done


### PR DESCRIPTION
### Motivation
- Ensure the repository CI runs the Python unit tests for the AlphaZero adapter located at `gomoku-battle-alphazero/tests` so Python-side regressions are caught.
- Make the `alphazero-board-games` submodule available in CI so the adapter can import and use the upstream library during tests.
- Provide a reproducible CI environment for both the Java multi-module build and the Python adapter tests.

### Description
- Updated `.github/workflows/ci.yml` to checkout submodules recursively by adding `submodules: recursive` to the `actions/checkout` step.
- Added Python setup using `actions/setup-python@v6` with `python-version: '3.12'` and an `Install Python dependencies` step that runs `pip install -e ./alphazero-board-games` and `pip install dotdict`.
- Added a CI step `Run AlphaZero adapter Python tests` which executes `python -m unittest discover -s gomoku-battle-alphazero/tests -p "test_*.py"` after the Maven test step.

### Testing
- Ran `python -m unittest discover -s gomoku-battle-alphazero/tests -p "test_*.py"` locally and it completed successfully (1 test, OK).
- Ran `mvn --batch-mode test` locally and it failed in this environment with `release version 25 not supported` because the local Java toolchain did not support Java 25; the CI workflow uses `actions/setup-java` to install Java 25 so this failure is an environment mismatch rather than a code issue.
- Python dependency installation (`pip install -e ./alphazero-board-games` and `pip install dotdict`) completed successfully in the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7d4d62b483268535f49eb6c79e84)