### PR TITLE
ci: fix dependency setup for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install -e ./alphazero-board-games
           pip install pytest
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,12 @@
 			<artifactId>commons-configuration2</artifactId>
 			<version>2.15.0</version>
 		</dependency>
+		<!-- Required by commons-configuration2 at runtime. -->
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.21.0</version>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
 		<dependency>
 			<groupId>commons-beanutils</groupId>


### PR DESCRIPTION
### Motivation

- Fix the CI Python job which attempted to resolve full CUDA-enabled `torch` wheels on Ubuntu runners by installing a CPU-only PyTorch wheel first.  
- Fix Maven test failures caused by `commons-configuration2` needing a runtime `commons-io` class that was not on the project classpath.

### Description

- Add `pip install torch --index-url https://download.pytorch.org/whl/cpu` to `.github/workflows/ci.yml` before installing the editable `alphazero-board-games` package.  
- Add an explicit `commons-io:commons-io:2.21.0` dependency to the root `pom.xml` so `commons-configuration2` can initialize at test runtime.  
- Commit with Conventional Commit message `ci: fix dependency setup for CI`.

### Testing

- Ran `mvn --batch-mode test` and the full Maven reactor tests completed successfully.  
- Created a Python venv and ran `pip install torch --index-url https://download.pytorch.org/whl/cpu && pip install -e ./alphazero-board-games && pip install pytest` and then `python -m pytest --ignore=alphazero-board-games`, and the Python tests passed (`1 passed`).  
- Ran `ruff` (`ruff check gomoku-battle-alphazero`) and linter checks reported all clear.  
- Verified `git diff --check` showed no whitespace or patch issues.

------
