### PR TITLE
ci: stabilize Python dependency setup and bump commons-io to 2.22.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,13 +28,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+          cache: pip
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install torch --index-url https://download.pytorch.org/whl/cpu
-          pip install -e ./alphazero-board-games
-          pip install pytest
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install pytest numpy
+          python -m pip install torch==2.12.0+cpu --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install --no-build-isolation --no-deps -e ./alphazero-board-games
 
       - name: Run Maven tests
         run: mvn --batch-mode test

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.21.0</version>
+			<version>2.22.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/commons-beanutils/commons-beanutils -->
 		<dependency>


### PR DESCRIPTION
### Motivation
- The commons-io version bump from PR #65 needed to be applied to the repository POM and the repository CI needed adjustments so Python dependency installation would be stable in CI runs. 
- The Python install step in CI must reliably install the AlphaZero submodule and the CPU PyTorch wheel without long build hangs or unexpected dependency re-resolution.

### Description
- Updated `pom.xml` to bump `commons-io:commons-io` from `2.21.0` to `2.22.0`.
- Updated `.github/workflows/ci.yml` to enable pip caching and use `python -m pip` consistently, install build tooling (`setuptools`, `wheel`) and common test deps (`pytest`, `numpy`), pin the CPU PyTorch wheel to `torch==2.12.0+cpu`, and install the `alphazero-board-games` submodule with `--no-build-isolation --no-deps` to avoid expensive rebuilds and dependency resolution in CI.

### Testing
- Ran `mvn --batch-mode -DskipTests compile` and it completed successfully.
- Ran `timeout 180 mvn --batch-mode test` and the full Maven test suite finished successfully (all Java tests passed).
- Installed the AlphaZero package locally with `python -m pip install --no-build-isolation --no-deps -e ./alphazero-board-games` and the install succeeded.
- Ran Python tests with `python -m pytest --ignore=alphazero-board-games` and `gomoku-battle-alphazero/tests/test_alphazero_adapter.py` passed.
- Ran the linter with `python -m ruff check gomoku-battle-alphazero` and there were no issues.

------
